### PR TITLE
Add viewport option

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,11 +137,12 @@ module.exports = function () {
         .argv;
 
       // building viewport option
+      var viewportDimensions, viewportWidth, viewportHeight, viewportOption;
       if( argv.viewport ) {
-        var viewportDimensions = argv.viewport.split(',');
-        var viewportWidth = +viewportDimensions[0];
-        var viewportHeight = +viewportDimensions[1];
-        var viewportOption = ( isNaN( viewportWidth ) || isNaN( viewportHeight ) ) ? {} : { width: viewportWidth, height: viewportHeight };
+        viewportDimensions = argv.viewport.split(',');
+        viewportWidth = +viewportDimensions[0];
+        viewportHeight = +viewportDimensions[1];
+        viewportOption = ( isNaN( viewportWidth ) || isNaN( viewportHeight ) ) ? {} : { width: viewportWidth, height: viewportHeight };
       }
 
       // run dalekjs


### PR DESCRIPTION
Since in the Dalek framework, there's a functional option to set dimensions of the viewport, it will be very helpful to have the possibility to pass a `--viewport` option within the dalek-cli.

It's very helpful for testing responsive & mobile design behaviours.

(_sorry for my very bad english. I try hard_)
